### PR TITLE
Add geolocation concern to the FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ To protect against attackers using the proxy to abuse websites, the prefetch pro
 
 We’re also considering potential schemes for authentication, as well as mechanisms by which website operators can opt-out of proxied prefetching (e.g., rejecting requests with the “Purpose: prefetch” header and potentially a blanket opt-out expressed in the DNS record). In addition, private prefetch proxies should allow for reverse DNS lookups of their IP addresses and publish an escalation path for help addressing potential abuse concerns. 
 
+## Geolocation
+**Concern:** "How will this work with geography based used case (e.g. Geo-filtering / Geo-access)?"
+
+The destination server will see the IP of the proxy egress IP, not the user's IP; this will interfere with IP-based geolocation. 
+Servers that rely on geolocation to determine what content to serve have the following options:
+* Determine the location of the user at navigation time, e.g., by triggering a request via JS.
+* Reject requests with the "Purpose: prefetch" for resources that are georestricted.
+
+
 ## Trusted Private Prefetch Proxies (TPPP)
 **Question**: “What are ‘trusted private prefetch proxies’?”
 


### PR DESCRIPTION
@jeremyroman
@KenjiBaheux

Added the two concrete options for the destination site. In the general case, I don't think a destination can know that a proxy has an egress IP in every country (or region) they care about. Also there is no obvious in-band way for the proxy to tell the destination what granular region the user is in. 

If you'd like, I can add those in as more speculative areas that could be explored. 