### PR TITLE
Automate building the traffic-advice spec.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+name: Build
+on:
+  pull_request:
+    branches:
+    - main
+  push:
+    branches:
+    - main
+  workflow_dispatch:
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: make ci
+    - name: Deploy
+      if: ${{ (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && github.ref == 'refs/heads/main' }}
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./out

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+out
+traffic-advice.html

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,30 @@
+SHELL=/bin/bash
+
+bikeshed_files = traffic-advice.bs
+
+.PHONY: ci clean local remote
+
+local: $(bikeshed_files)
+	$(foreach source,$(bikeshed_files),bikeshed --die-on=warning spec $(source) $(source:.bs=.html);)
+
+remote: $(bikeshed_files:.bs=.html)
+
+ci: $(bikeshed_files:.bs=.html)
+	mkdir -p out
+	cp $^ out/
+
+clean:
+	rm -f $(bikeshed_files:.bs=.html)
+
+%.html: %.bs
+	@ (HTTP_STATUS=$$(curl https://api.csswg.org/bikeshed/ \
+	                       --output $@ \
+	                       --write-out "%{http_code}" \
+	                       --header "Accept: text/plain, text/html" \
+												 -F die-on=warning \
+	                       -F file=@$<) && \
+	[[ "$$HTTP_STATUS" -eq "200" ]]) || ( \
+		echo ""; cat $@; echo ""; \
+		rm -f $@; \
+		exit 22 \
+	);


### PR DESCRIPTION
This might also require enabling GitHub Actions and GitHub Pages in the repository settings, but once both of those are done it should make this file get published automatically instead of us doing it ad-hoc.